### PR TITLE
Fix contact util and GA context

### DIFF
--- a/sola_thomas_website/context_processors.py
+++ b/sola_thomas_website/context_processors.py
@@ -5,5 +5,5 @@ def analytics(request):
     Adds Google Analytics tracking ID to the template context
     """
     return {
-        'GA_TRACKING_ID': getattr(settings, 'GA_TRACKING_ID', ''),
+        'GOOGLE_ANALYTICS_ID': getattr(settings, 'GOOGLE_ANALYTICS_ID', ''),
     }

--- a/sola_thomas_website/core/views.py
+++ b/sola_thomas_website/core/views.py
@@ -10,7 +10,8 @@ import json
 
 # Import the custom forms and email utilities
 from .forms import ContactForm
-from .email import send_email, send_contact_notification
+from .email import send_email
+from utils import send_contact_notification
 
 # Set up logger
 logger = logging.getLogger(__name__)

--- a/sola_thomas_website/settings.py
+++ b/sola_thomas_website/settings.py
@@ -1,7 +1,7 @@
 # Google Analytics Settings
-GA_TRACKING_ID = 'G-24QFBN3WGN'
+GOOGLE_ANALYTICS_ID = 'G-24QFBN3WGN'
 
-# Add GA_TRACKING_ID to the template context
+# Add GOOGLE_ANALYTICS_ID to the template context
 TEMPLATES = [
     {
         'OPTIONS': {

--- a/sola_thomas_website/templates/base.html
+++ b/sola_thomas_website/templates/base.html
@@ -37,12 +37,12 @@
     {% endblock %}
     
     <!-- Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{ GA_TRACKING_ID }}"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ GOOGLE_ANALYTICS_ID }}"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', '{{ GA_TRACKING_ID }}');
+        gtag('config', '{{ GOOGLE_ANALYTICS_ID }}');
     </script>
 </head>
 <body>

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,27 @@
+from django.core.mail import send_mail
+from django.conf import settings
+
+
+def send_contact_notification(data):
+    """Send email notification for contact form submissions.
+
+    Parameters
+    ----------
+    data : dict
+        Dictionary containing 'name', 'email', and 'message' keys.
+    Returns
+    -------
+    int or None
+        Status code (always 1 in Django's send_mail) if mail sent, else None.
+    """
+    subject = 'New Contact Form Submission'
+    body = (
+        f"Name: {data.get('name')}\n"
+        f"Email: {data.get('email')}\n"
+        f"Message: {data.get('message')}"
+    )
+    try:
+        return send_mail(subject, body, settings.DEFAULT_FROM_EMAIL, [settings.CONTACT_EMAIL])
+    except Exception:
+        return None
+


### PR DESCRIPTION
## Summary
- add missing `utils.send_contact_notification`
- expose `GOOGLE_ANALYTICS_ID` through settings and templates
- switch contact view to use new util

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684077c1e504832b88f8c94ee32ac231